### PR TITLE
Add Conda & Pixi installation method

### DIFF
--- a/site/docs/getting_started/installation.md
+++ b/site/docs/getting_started/installation.md
@@ -137,3 +137,18 @@ in {
 :::
 
 > Thanks to [`Hyprpanel`](https://hyprpanel.com/) from whom I stole the format for the flake
+
+## Conda
+
+```bash
+conda install dooit dooit-extras
+```
+
+```bash
+mamba install dooit dooit-extras
+```
+
+Or using [Pixi](https://pixi.sh/latest/)s `global` feature for access independent of the directory:
+```bash
+pixi global install dooit
+```


### PR DESCRIPTION
I added dooit to conda-forge, so it is installable using Pixi, which fits my workflow well.
The dooit-extras feedstock is ~~currently under review~~ ready!

I also updated the installation hints, hence the PR.

@kraanzu Would also be happy to add you or someone else as a maintainer on the feedstock, if you like.