### PR TITLE
Fixing failing tests for NixOS

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -51,6 +51,7 @@ python3.pkgs.buildPythonApplication rec {
 
   checkInputs = with python3.pkgs; [
     pytestCheckHook
+    pytest-asyncio
     faker
   ];
 


### PR DESCRIPTION
When installing through the flake on NixOS, multiple tests were failing with  
```
Failed: async def functions are not natively supported.
```
Added pytest-asyncio as a dependency for the tests.