### PR TITLE
Fix/stale todo tree on workspace delete

### DIFF
--- a/dooit/ui/screens/index.py
+++ b/dooit/ui/screens/index.py
@@ -20,6 +20,7 @@ from dooit.ui.api.events import (
     TodoUrgencyChanged,
     WorkspaceDescriptionChanged,
     WorkspaceSelected,
+    WorkspaceRemoved,
     SwitchTab,
     SpawnHelp,
     BarNotification,
@@ -119,8 +120,23 @@ class MainScreen(BaseScreen):
         else:
             switcher.current = tree.id
 
-    # SQLAlchemy event listeners
+    @on(WorkspaceRemoved)
+    def workspace_removed(self, event: WorkspaceRemoved):
+        tree_id = f"TodosTree_{event.workspace.uuid}"
+        from textual.css.query import NoMatches
+        try:
+            switcher = self.query_one("#todo_switcher", expect_type=ContentSwitcher)
+            if switcher.current == tree_id:
+                switcher.current = "dooit-dashboard" 
+            widget = switcher.query_one(f"#{tree_id}")
+            widget.remove()
+        except NoMatches:
+            pass
+        except Exception as e:
+            self.app.log.error(f"Failed to remove workspace UI for {tree_id}: {e}")
+            raise  
 
+    # SQLAlchemy event listeners
     def _track_field(
         self, table: Type[DooitModel], field: str, event: Type[DooitEvent]
     ) -> None:

--- a/dooit/ui/widgets/trees/model_tree.py
+++ b/dooit/ui/widgets/trees/model_tree.py
@@ -311,6 +311,9 @@ class ModelTree(BaseTree, Generic[ModelType, RenderDictType]):
 
         self.highlight_id(node.uuid)
         self.start_edit("description")
+    
+    def _after_node_removed(self, model: ModelType) -> None:
+        pass
 
     @require_confirmation
     @refresh_tree
@@ -320,6 +323,7 @@ class ModelTree(BaseTree, Generic[ModelType, RenderDictType]):
         self._renderers.pop(model.uuid)
         self.expanded_nodes.pop(model.uuid)
         model.drop()
+        self._after_node_removed(model)
 
     @require_highlighted_node
     def copy_model_to_clipboard(self):

--- a/dooit/ui/widgets/trees/todos_tree.py
+++ b/dooit/ui/widgets/trees/todos_tree.py
@@ -49,11 +49,8 @@ class TodosTree(ModelTree[Model, TodoRenderDict]):
     def _create_child_node(self) -> Todo:
         return self.current_model.add_todo()
 
-    def _remove_node(self) -> None:
-        assert isinstance(self.current_model, Todo)
-        self.post_message(TodoRemoved(self.current_model))
-
-        return super()._remove_node()
+    def _after_node_removed(self, model:Todo) -> None:
+        self.screen.post_message(TodoRemoved(model))
 
     def toggle_complete(self):
         assert isinstance(self.current_model, Todo)
@@ -79,3 +76,4 @@ class TodosTree(ModelTree[Model, TodoRenderDict]):
 
         event.stop()
         self.post_message(TodoSelected(Todo.from_id(event.option_id)))
+    

--- a/dooit/ui/widgets/trees/workspaces_tree.py
+++ b/dooit/ui/widgets/trees/workspaces_tree.py
@@ -50,9 +50,8 @@ class WorkspacesTree(ModelTree[Workspace, WorkspaceRenderDict]):
     def _add_first_item(self) -> Workspace:
         return self.model.add_workspace()
 
-    def _remove_node(self) -> None:
-        self.post_message(WorkspaceRemoved(self.current_model))
-        return super()._remove_node()
+    def _after_node_removed(self, model:Workspace) -> None:
+        self.screen.post_message(WorkspaceRemoved(model))
 
     @on(ModelTree.OptionHighlighted)
     def workspace_highlighted(self, event: ModelTree.OptionHighlighted):


### PR DESCRIPTION
**The Problem**
After deleting a workspace, its corresponding TodosTree UI remains in the #todo_switcher, even though the workspace and its todos have already been cascade-deleted from the database.

This leads to:
If the user deletes the last remaining workspace, the TodosTree is still shown in the UI — even though its data is gone.
If the user deletes a workspace and then creates a new one with the same name, the old (now orphaned) TodosTree may be reused, which can cause errors or crashes when interacting with it.

**The Solution**
Added a hook method in ModelTree._remove_node that can be overridden by subclasses to emit messages at the right time.
The main screen listens for this message and immediately clears the #todo_switcher.

I noticed your previous code already included a WorkspaceRemoved message — great design! However, it was emitted before the delete confirmation dialog.
I’ve moved the emission to after confirmation and actual deletion, so the message only fires when the model is truly removed