### PR TITLE
Add docstrings to api_components public API

### DIFF
--- a/dooit/ui/api/api_components/bar.py
+++ b/dooit/ui/api/api_components/bar.py
@@ -7,11 +7,17 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 class BarManager(ApiComponent):
+    """
+    Manages the status bar widgets displayed in the Dooit application.
+    Provides methods to configure which widgets appear in the status bar.
+    """
+
     def __init__(self, api: "DooitAPI") -> None:
         super().__init__()
         self.api = api
 
     def set(self, widgets: List[StatusBarWidget]):
+        """Set the status bar widgets, registering their functions with the plugin manager."""
         for widget in widgets:
             self.api.plugin_manager.register(widget.func)
 

--- a/dooit/ui/api/api_components/dashboard.py
+++ b/dooit/ui/api/api_components/dashboard.py
@@ -8,9 +8,15 @@ from ._base import ApiComponent
 
 
 class DashboardManager(ApiComponent):
+    """
+    Manages the dashboard content displayed in the Dooit application.
+    Provides methods to configure the items shown on the dashboard screen.
+    """
+
     def __init__(self, app: App) -> None:
         super().__init__()
         self.app = app
 
     def set(self, items: List[TextType]):
+        """Set the dashboard display items."""
         self.app.screen.query_one(Dashboard).items = items

--- a/dooit/ui/api/api_components/keys.py
+++ b/dooit/ui/api/api_components/keys.py
@@ -12,6 +12,11 @@ KeyType = Union[str, List[str]]
 
 @dataclass
 class DooitFunction:
+    """
+    Represents a callable function bound to a key in Dooit,
+    along with its description and grouping metadata.
+    """
+
     callback: Callable
     description: str = ""
     group: str = ""
@@ -21,6 +26,11 @@ class DooitFunction:
 
 
 class KeyMatchType(Enum):
+    """
+    Enumeration of possible outcomes when matching a key sequence
+    against registered keybindings.
+    """
+
     NoMatchFound = "NoMatchFound"
     MultipleMatchFound = "MultipleMatchFound"
     MatchFound = "MatchFound"
@@ -28,23 +38,37 @@ class KeyMatchType(Enum):
 
 @dataclass
 class KeyMatch:
+    """
+    Represents the result of attempting to match a key sequence
+    against registered keybindings, containing the match type
+    and optionally the matched function.
+    """
+
     match_type: KeyMatchType
     function: Optional[DooitFunction] = None
 
     @staticmethod
     def no_match():
+        """Create a KeyMatch indicating no matching keybinding was found."""
         return KeyMatch(match_type=KeyMatchType.NoMatchFound)
 
     @staticmethod
     def multiple_match():
+        """Create a KeyMatch indicating multiple potential matches exist."""
         return KeyMatch(match_type=KeyMatchType.MultipleMatchFound)
 
     @staticmethod
     def match_found(func: DooitFunction):
+        """Create a KeyMatch indicating an exact match was found for the given function."""
         return KeyMatch(match_type=KeyMatchType.MatchFound, function=func)
 
 
 class KeyManager(ApiComponent):
+    """
+    Manages keybinding registration and key sequence matching for the Dooit application.
+    Tracks user key inputs and resolves them against registered keybindings.
+    """
+
     def __init__(self, get_mode: Callable) -> None:
         self.keybinds: KeyBindType = defaultdict(lambda: defaultdict(lambda: None))
         self._inputs: List[str] = []
@@ -52,11 +76,13 @@ class KeyManager(ApiComponent):
 
     @property
     def groups(self) -> List[str]:
+        """Return a sorted list of unique keybinding group names in NORMAL mode."""
         return list(
             sorted(set(func.group for func in self.keybinds["NORMAL"].values() if func))
         )
 
     def get_keybinds_by_group(self, group: str) -> List[Tuple[str, DooitFunction]]:
+        """Return all keybindings in NORMAL mode that belong to the specified group."""
         return [
             (key, func)
             for key, func in self.keybinds["NORMAL"].items()
@@ -82,6 +108,7 @@ class KeyManager(ApiComponent):
         description: Optional[str] = None,
         group: str = "",
     ) -> None:
+        """Register a callback for one or more keys in NORMAL mode."""
         if isinstance(keys, str):
             keys = [keys]
 
@@ -90,6 +117,7 @@ class KeyManager(ApiComponent):
 
     @property
     def input(self) -> str:
+        """Return the current accumulated key input as a formatted string."""
         formatted = ""
         for i in self._inputs:
             if len(i) > 1:
@@ -100,6 +128,7 @@ class KeyManager(ApiComponent):
         return formatted
 
     def clear_input(self):
+        """Clear all accumulated key inputs."""
         self._inputs.clear()
 
     def _find_matched_functions(self) -> List[DooitFunction]:
@@ -107,6 +136,7 @@ class KeyManager(ApiComponent):
         return [func for key, func in keybinds if key.startswith(self.input) and func]
 
     def search_for_key(self) -> KeyMatch:
+        """Search for a keybinding match based on the current accumulated input."""
         matched = self._find_matched_functions()
         if not matched:
             self.clear_input()
@@ -119,6 +149,7 @@ class KeyManager(ApiComponent):
         return KeyMatch.match_found(matched[0])
 
     def register_key(self, key: str) -> KeyMatch:
+        """Register a key press and return the resulting match status."""
         if key == "escape":
             self.clear_input()
             return KeyMatch.no_match()

--- a/dooit/ui/api/api_components/layout.py
+++ b/dooit/ui/api/api_components/layout.py
@@ -5,6 +5,12 @@ from ._base import ApiComponent
 
 
 class LayoutManager(ApiComponent):
+    """
+    Manages the column layout configuration for workspace and todo trees
+    in the Dooit application. Changes to layouts automatically refresh
+    the corresponding tree widgets.
+    """
+
     def __init__(self, app: App) -> None:
         self.app = app
         self._todo_layout: TodoLayout = []
@@ -12,20 +18,24 @@ class LayoutManager(ApiComponent):
 
     @property
     def todo_layout(self) -> TodoLayout:
+        """Return the current todo tree column layout."""
         return self._todo_layout
 
     @todo_layout.setter
     def todo_layout(self, layout: TodoLayout):
+        """Set the todo tree column layout and refresh all todo tree widgets."""
         self._todo_layout = layout
         for tree in self.app.screen.query(TodosTree):
             tree.refresh_options()
 
     @property
     def workspace_layout(self) -> WorkspaceLayout:
+        """Return the current workspace tree column layout."""
         return self._workspace_layout
 
     @workspace_layout.setter
     def workspace_layout(self, layout: WorkspaceLayout):
+        """Set the workspace tree column layout and refresh all workspace tree widgets."""
         self._workspace_layout = layout
         for tree in self.app.screen.query(WorkspacesTree):
             tree.refresh_options()

--- a/dooit/ui/api/api_components/vars.py
+++ b/dooit/ui/api/api_components/vars.py
@@ -14,6 +14,12 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 class VarManager(ApiComponent):
+    """
+    Manages application-level variables and state for the Dooit application.
+    Provides access to configuration flags, the current mode, theme,
+    and references to the workspace and todo tree widgets and their models.
+    """
+
     def __init__(self, api: "DooitAPI") -> None:
         super().__init__()
         self.api = api
@@ -23,42 +29,52 @@ class VarManager(ApiComponent):
 
     @property
     def always_expand_workspaces(self) -> bool:
+        """Return whether workspace nodes should always be expanded."""
         return self._always_expand_workspaces
 
     @always_expand_workspaces.setter
     def always_expand_workspaces(self, value: bool):
+        """Set whether workspace nodes should always be expanded."""
         self._always_expand_workspaces = value
 
     @property
     def always_expand_todos(self) -> bool:
+        """Return whether todo nodes should always be expanded."""
         return self._always_expand_todos
 
     @always_expand_todos.setter
     def always_expand_todos(self, value: bool):
+        """Set whether todo nodes should always be expanded."""
         self._always_expand_todos = value
 
     @property
     def show_confirm(self):
+        """Return whether confirmation prompts are enabled."""
         return self._show_confirm
 
     @show_confirm.setter
     def show_confirm(self, value: bool):
+        """Set whether confirmation prompts are enabled."""
         self._show_confirm = value
 
     @property
     def mode(self) -> str:
+        """Return the current Dooit application mode."""
         return self.api.app.dooit_mode
 
     @property
     def theme(self) -> DooitThemeBase:
+        """Return the current Dooit theme."""
         return self.api.css.theme
 
     @property
     def workspaces_tree(self) -> WorkspacesTree:
+        """Return the workspaces tree widget from the current screen."""
         return self.api.app.screen.query_one(WorkspacesTree)
 
     @property
     def current_workspace(self) -> Optional[Workspace]:
+        """Return the currently highlighted workspace, or None if nothing is highlighted."""
         tree = self.api.vars.workspaces_tree
         if tree.highlighted is None:
             return None
@@ -67,6 +83,7 @@ class VarManager(ApiComponent):
 
     @property
     def todos_tree(self) -> Optional[TodosTree]:
+        """Return the currently visible todos tree widget, or None if not visible."""
         todo_switcher = self.api.app.screen.query_one(
             "#todo_switcher", expect_type=ContentSwitcher
         )
@@ -77,6 +94,7 @@ class VarManager(ApiComponent):
 
     @property
     def current_todo(self) -> Optional[Todo]:
+        """Return the currently highlighted todo item, or None if nothing is highlighted."""
         tree = self.todos_tree
         if tree is None:
             return


### PR DESCRIPTION
## Summary
- Add triple double-quote docstrings to all public classes and methods in `dooit/ui/api/api_components/` (excluding `formatters/`)
- Covers `bar.py`, `dashboard.py`, `keys.py`, `layout.py`, and `vars.py`
- No code logic was modified; docstrings only

## Test plan
- [x] All modified files compile without syntax errors (`py_compile`)
- [x] Docstring-only change with no logic modifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)