### PR TITLE
Add docstrings to public classes and methods in ui/api

### DIFF
--- a/dooit/ui/api/dooit_api.py
+++ b/dooit/ui/api/dooit_api.py
@@ -21,6 +21,13 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 class DooitAPI:
+    """
+    Central API for interacting with the Dooit application.
+
+    Provides methods for navigation, editing, clipboard operations,
+    and plugin/event management within the TUI.
+    """
+
     def __init__(
         self,
         app: "Dooit",
@@ -46,9 +53,11 @@ class DooitAPI:
         self.app.post_message(QuitApp())
 
     def notify(self, message: str, level: NotificationType = "info") -> None:
+        """Display a notification message in the status bar."""
         self.app.bar_switcher.switch_to_notification(BarNotification(message, level))
 
     async def handle_key(self, key: str) -> None:
+        """Handle a keypress by dispatching to registered keybindings or the focused widget."""
         keymatch = self.keys.register_key(key)
 
         if keymatch.match_type == KeyMatchType.NoMatchFound:
@@ -67,12 +76,14 @@ class DooitAPI:
             )
 
     def trigger_event(self, event: DooitEvent):
+        """Trigger a DooitEvent and notify all registered plugin handlers."""
         self.plugin_manager.on_event(event)
 
     # -----------------------------------------
 
     @property
     def focused(self) -> ModelTree:
+        """Return the currently focused ModelTree widget."""
         focused = self.app.focused
         if isinstance(focused, ModelTree):
             return focused
@@ -150,6 +161,7 @@ class DooitAPI:
         return self.edit("recurrence")
 
     def edit_effort(self):
+        """Start editing the effort of the todo."""
         return self.edit("effort")
 
     def add_sibling(self):

--- a/dooit/ui/api/loader.py
+++ b/dooit/ui/api/loader.py
@@ -26,6 +26,7 @@ def temporary_sys_path(path: Path):
 
 
 def register(api: "PluginManager", path: Path) -> None:
+    """Dynamically load a Python module from the given path and register its objects with the plugin manager."""
     module_name = f"dynamic_{path.stem}"
     spec = importlib.util.spec_from_file_location(module_name, path)
 
@@ -41,6 +42,7 @@ def register(api: "PluginManager", path: Path) -> None:
 
 
 def load_file(api: "PluginManager", path: Path) -> bool:
+    """Load a plugin file and register its contents, returning True if the file exists."""
     if not path.exists():
         return False
 

--- a/dooit/ui/api/plug.py
+++ b/dooit/ui/api/plug.py
@@ -26,10 +26,16 @@ DEFAULT_CONFIG = BASE_PATH / "utils" / "default_config.py"
 
 
 def is_running_under_pytest() -> bool:
+    """Check whether the current process is running under pytest."""
     return "PYTEST_CURRENT_TEST" in os.environ
 
 
 class PluginManager:
+    """
+    Manages plugin registration, event dispatching, and timer scheduling
+    for the Dooit application.
+    """
+
     def __init__(self, api: "DooitAPI", config: Optional[Path] = None) -> None:
         self.config = config or CONFIG_FILE
         self.events: defaultdict[Type[DooitEvent], List[Callable]] = defaultdict(list)
@@ -38,6 +44,7 @@ class PluginManager:
         self.app = api.app
 
     def scan(self):
+        """Load and register plugins from the default and user configuration files."""
         load_file(self, DEFAULT_CONFIG)
         if is_running_under_pytest():
             return
@@ -55,6 +62,7 @@ class PluginManager:
             pass
 
     def on_event(self, event: DooitEvent):
+        """Dispatch a DooitEvent to all matching registered event handlers."""
         matched_events = [
             e for e in self.events.keys() if issubclass(event.__class__, e)
         ]
@@ -74,6 +82,7 @@ class PluginManager:
             self.api.app.set_interval(interval, func)
 
     def register(self, obj):
+        """Register a callable as an event handler or timer based on its attributes."""
         if event := getattr(obj, DOOIT_EVENT_ATTR, None):
             return self._register_events(event, obj)
 

--- a/dooit/ui/api/widgets.py
+++ b/dooit/ui/api/widgets.py
@@ -3,10 +3,18 @@ from typing import List
 
 
 class WorkspaceWidget(Enum):
+    """
+    Enum of available widget columns for workspace rows in the layout.
+    """
+
     description = "description"
 
 
 class TodoWidget(Enum):
+    """
+    Enum of available widget columns for todo rows in the layout.
+    """
+
     description = "description"
     due = "due"
     urgency = "urgency"


### PR DESCRIPTION
## Summary
- Add triple double-quote docstrings to all public classes and methods missing them in `dooit/ui/api/` top-level files
- Covers `dooit_api.py`, `plug.py`, `loader.py`, and `widgets.py`
- No code logic changes; docstring-only additions

## Test plan
- [x] Verified changes are docstring-only via `git diff`
- [x] No logic, imports, or signatures were modified
- [x] Existing tests should pass unchanged (docstring-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)