### PR TITLE
Add docstrings to public classes and methods in inputs widgets

### DIFF
--- a/dooit/ui/widgets/inputs/_input.py
+++ b/dooit/ui/widgets/inputs/_input.py
@@ -17,9 +17,11 @@ class Input:
 
     @property
     def value(self) -> str:
+        """Return the current text value of the input."""
         return self._value
 
     def draw(self) -> str:
+        """Return the display text, including the cursor if currently editing."""
         if self.is_editing:
             text = self._render_text_with_cursor()
         else:
@@ -28,6 +30,7 @@ class Input:
         return text
 
     def render(self) -> str:
+        """Return the drawn text with leading and trailing whitespace removed."""
         return self.draw().strip()
 
     def _render_text_with_cursor(self) -> str:
@@ -42,9 +45,11 @@ class Input:
         )
 
     def start_edit(self) -> None:
+        """Enable editing mode for the input."""
         self.is_editing = True
 
     def stop_edit(self) -> None:
+        """Disable editing mode for the input."""
         self.is_editing = False
 
     def _insert_text(self, text: Optional[str] = None) -> None:
@@ -121,14 +126,17 @@ class Input:
             self._cursor_position = prev  # Because the cursor never actually moved :)
 
     def clear_input(self) -> None:
+        """Clear all text from the input by simulating backspace from the end."""
         self.move_cursor_to_end()
         while self._value:
             self.keypress("backspace")
 
     def move_cursor_to_end(self) -> None:
+        """Move the cursor to the end of the current text."""
         self._cursor_position = len(self._value)
 
     def keypress(self, key: str) -> None:
+        """Handle a keypress event and update the input state accordingly."""
         # Moving backward
         if key == "left":
             self._move_cursor_backward()

--- a/dooit/ui/widgets/inputs/model_inputs.py
+++ b/dooit/ui/widgets/inputs/model_inputs.py
@@ -8,18 +8,24 @@ from dooit.utils import parse
 
 
 class TodoDescription(SimpleInput[Todo, str]):
+    """Input widget for editing a Todo item's description."""
+
     @property
     def _property(self) -> str:
         return "description"
 
 
 class WorkspaceDescription(SimpleInput[Workspace, str]):
+    """Input widget for editing a Workspace item's description."""
+
     @property
     def _property(self) -> str:
         return "description"
 
 
 class Due(SimpleInput[Todo, datetime]):
+    """Input widget for editing a Todo item's due date."""
+
     def _get_default_value(self) -> str:
         value = self.model_value
 
@@ -43,8 +49,11 @@ class Due(SimpleInput[Todo, datetime]):
 
 
 class Urgency(SimpleInput[Todo, int]):
+    """Input widget for editing a Todo item's urgency level."""
+
     @property
     def value(self) -> str:
+        """Return the urgency as a string, or empty string if zero."""
         res = self.model.urgency
 
         if res == 0:
@@ -60,6 +69,8 @@ class Urgency(SimpleInput[Todo, int]):
 
 
 class Effort(SimpleInput[Todo, int]):
+    """Input widget for editing a Todo item's effort estimate."""
+
     def _typecast_value(self, value: str) -> Any:
         if not value or value == "0":
             return 0
@@ -68,6 +79,8 @@ class Effort(SimpleInput[Todo, int]):
 
 
 class Status(SimpleInput[Todo, str]):
+    """Input widget for displaying and toggling a Todo item's completion status."""
+
     def _get_default_value(self) -> str:
         val = self.model_value
 
@@ -87,8 +100,11 @@ class Status(SimpleInput[Todo, str]):
 
 
 class Recurrence(SimpleInput[Todo, timedelta]):
+    """Input widget for editing a Todo item's recurrence interval."""
+
     @staticmethod
     def parse_recurrence(recurrence: str) -> timedelta:
+        """Parse a recurrence string like '2d' or '1w' into a timedelta."""
         DURATION_LEGEND = {
             "m": "minute",
             "h": "hour",
@@ -114,6 +130,7 @@ class Recurrence(SimpleInput[Todo, timedelta]):
 
     @staticmethod
     def timedelta_to_simple_string(td: timedelta):
+        """Convert a timedelta to a compact string like '2d', '1w', '3h', or '5m'."""
         if td.days >= 7 and td.days % 7 == 0:
             weeks = td.days // 7
             return f"{weeks}w"

--- a/dooit/ui/widgets/inputs/simple_input.py
+++ b/dooit/ui/widgets/inputs/simple_input.py
@@ -32,20 +32,24 @@ class SimpleInput(Input, Generic[ModelType, ModelValue]):
 
     @property
     def model_value(self) -> ModelValue:
+        """Return the current value of the bound model property."""
         return getattr(self.model, self._property)
 
     @model_value.setter
     def model_value(self, value: str) -> None:
+        """Set the value of the bound model property."""
         return setattr(self.model, self._property, value)
 
     def _typecast_value(self, value: str) -> Any:
         return value
 
     def reset(self) -> str:
+        """Reset the cursor position to the end of the value and return the value."""
         self._cursor_pos = len(self.value)
         return self.value
 
     def stop_edit(self) -> None:
+        """Stop editing, persist the value to the model, and reset the display."""
         self._value = self.value.strip()
         try:
             self.model_value = self._typecast_value(self.value)
@@ -56,4 +60,5 @@ class SimpleInput(Input, Generic[ModelType, ModelValue]):
             self.move_cursor_to_end()
 
     def keypress(self, key: str) -> None:
+        """Handle a keypress event by delegating to the parent Input."""
         super().keypress(key)


### PR DESCRIPTION
## Summary
- Added triple double-quote docstrings to all public classes and methods in `dooit/ui/widgets/inputs/`
- Covers `_input.py` (Input class), `simple_input.py` (SimpleInput class), and `model_inputs.py` (TodoDescription, WorkspaceDescription, Due, Urgency, Effort, Status, Recurrence)
- Docstring-only change; no code logic was modified

## Test plan
- [x] Verified no logic changes via `git diff`
- [x] Reviewed for code quality, reuse, and efficiency (all clean — docstrings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)