### PR TITLE
Add docstrings to public API classes and methods

### DIFF
--- a/dooit/api/manager.py
+++ b/dooit/api/manager.py
@@ -39,6 +39,10 @@ class Manager:
             return None
 
     def has_changed(self) -> bool:
+        """
+        Check if the database file has been modified since the last known state.
+        """
+
         current_last_modified = self._get_db_last_modified()
         if current_last_modified and self._db_last_modified != current_last_modified:
             self._db_last_modified = current_last_modified
@@ -47,14 +51,26 @@ class Manager:
         return False
 
     def delete(self, obj):
+        """
+        Delete an object from the database and commit the change.
+        """
+
         self.session.delete(obj)
         self.commit()
 
     def save(self, obj):
+        """
+        Add an object to the session and commit the change.
+        """
+
         self.session.add(obj)
         self.commit()
 
     def commit(self):
+        """
+        Commit the current session and update the last-modified timestamp.
+        """
+
         self.session.commit()
         self._db_last_modified = self._get_db_last_modified()
 

--- a/dooit/api/model.py
+++ b/dooit/api/model.py
@@ -12,10 +12,18 @@ T = TypeVar("T")
 
 
 class BaseModel(DeclarativeBase):
+    """
+    SQLAlchemy declarative base for all dooit database models.
+    """
+
     pass
 
 
 class BaseModelMixin:
+    """
+    Mixin that provides automatic table name generation from the class name.
+    """
+
     @declared_attr
     def __tablename__(cls):
         return cls.__name__.lower()
@@ -38,6 +46,10 @@ class DooitModel(BaseModel, BaseModelMixin):
 
     @classmethod
     def comparable_fields(cls):
+        """
+        Return a list of column names that can be used for sorting and comparison.
+        """
+
         to_ignore = ["id", "order_index", "is_root"]
 
         comparable_fields = [
@@ -50,14 +62,18 @@ class DooitModel(BaseModel, BaseModelMixin):
 
     @property
     def uuid(self) -> str:
+        """Return a unique identifier string combining the class name and id."""
         return f"{self.__class__.__name__}_{self.id}"
 
     @property
     def parent(self) -> Any:
+        """Return the parent node of this model."""
         raise NotImplementedError  # pragma: no cover
 
     @property
     def nest_level(self):
+        """Return the nesting depth of this node relative to its top-level ancestor."""
+
         level = 0
         parent = self.parent
 
@@ -73,30 +89,39 @@ class DooitModel(BaseModel, BaseModelMixin):
 
     @property
     def siblings(self) -> List[Any]:
+        """Return a list of sibling nodes sharing the same parent."""
         raise NotImplementedError  # pragma: no cover
 
     @classmethod
     def from_id(cls, _id: str) -> Self:
+        """Look up and return a model instance by its string identifier."""
         raise NotImplementedError  # pragma: no cover
 
     @property
     def session(self):
+        """Return the current SQLAlchemy session from the manager."""
         return manager.session
 
     def is_last_sibling(self) -> bool:
+        """Check whether this node is the last among its siblings."""
         return self.siblings[-1].id == self.id
 
     def is_first_sibling(self) -> bool:
+        """Check whether this node is the first among its siblings."""
         return self.siblings[0].id == self.id
 
     @property
     def has_same_parent_kind(self) -> bool:
+        """Check whether the parent is the same type as this node."""
         raise NotImplementedError  # pragma: no cover
 
     def sort_siblings(self, field: str):
+        """Sort sibling nodes by the given field name."""
         raise NotImplementedError  # pragma: no cover
 
     def reverse_siblings(self):
+        """Reverse the ordering of all siblings."""
+
         for index, model in enumerate(reversed(self.siblings)):
             model.order_index = index
 
@@ -125,6 +150,7 @@ class DooitModel(BaseModel, BaseModelMixin):
         raise NotImplementedError  # pragma: no cover
 
     def add_sibling(self):
+        """Create and return a new sibling node adjacent to this one."""
         return self._add_sibling()
 
     def shift_down(self) -> bool:
@@ -147,11 +173,14 @@ class DooitModel(BaseModel, BaseModelMixin):
         return True
 
     def drop(self) -> None:
+        """Delete this node from the database."""
         manager.delete(self)
 
     def save(self) -> None:
+        """Persist this node to the database."""
         manager.save(self)
 
     @staticmethod
     def clone_from_id(id: int, order_index: int) -> "DooitModel":
+        """Create a duplicate of the model identified by the given id."""
         raise NotImplementedError

--- a/dooit/api/theme.py
+++ b/dooit/api/theme.py
@@ -1,4 +1,8 @@
 class DooitThemeBase:
+    """
+    Base theme class defining the color palette used throughout the dooit UI.
+    """
+
     _name: str = "dooit-base"
 
     # background colors
@@ -27,6 +31,8 @@ class DooitThemeBase:
 
     @classmethod
     def to_css(cls) -> str:
+        """Convert the theme colors into a CSS variable string for use in stylesheets."""
+
         css = f"""\
 $background1: {cls.background1};
 $background2: {cls.background2};

--- a/dooit/api/todo.py
+++ b/dooit/api/todo.py
@@ -12,6 +12,10 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 class Todo(DooitModel):
+    """
+    Model representing a todo item, which can be nested under a Workspace or another Todo.
+    """
+
     # id: Mapped[int] = mapped_column(primary_key=True, default=generate_unique_id)
     id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
     order_index: Mapped[int] = mapped_column(default=-1)
@@ -57,6 +61,8 @@ class Todo(DooitModel):
 
     @classmethod
     def from_id(cls, _id: str) -> "Todo":
+        """Look up and return a Todo instance by its string identifier."""
+
         _id = _id.lstrip("Todo_")
         query = select(Todo).where(Todo.id == _id)
         res = manager.session.execute(query).scalars().first()
@@ -65,6 +71,8 @@ class Todo(DooitModel):
 
     @property
     def parent(self) -> Union["Workspace", "Todo"]:
+        """Return the parent node, which is either a Workspace or another Todo."""
+
         assert self.parent_workspace or self.parent_todo
 
         if self.parent_workspace:
@@ -76,14 +84,18 @@ class Todo(DooitModel):
 
     @property
     def has_same_parent_kind(self) -> bool:
+        """Check whether the parent is also a Todo."""
         return self.parent_todo is not None
 
     @property
     def tags(self) -> List[str]:
+        """Extract and return all @-prefixed tags from the description."""
         return [i for i in self.description.split() if i[0] == "@"]
 
     @property
     def status(self) -> str:
+        """Return the current status string: 'completed', 'overdue', or 'pending'."""
+
         if self.is_completed:
             return "completed"
 
@@ -94,6 +106,8 @@ class Todo(DooitModel):
 
     @property
     def siblings(self) -> List["Todo"]:
+        """Return a list of sibling Todo items sharing the same parent."""
+
         if self.parent_workspace:
             return self.parent_workspace.todos
 
@@ -103,6 +117,8 @@ class Todo(DooitModel):
         return []
 
     def sort_siblings(self, field: str):
+        """Sort sibling todos by the given field name."""
+
         if field != "pending":
             items = (
                 self.session.query(Todo)
@@ -129,6 +145,8 @@ class Todo(DooitModel):
         manager.commit()
 
     def add_todo(self) -> "Todo":
+        """Create and return a new child Todo nested under this one."""
+
         todo = Todo(parent_todo=self)
         todo.save()
         return todo
@@ -145,18 +163,23 @@ class Todo(DooitModel):
     # ----------- HELPER FUNCTIONS --------------
 
     def increase_urgency(self) -> None:
+        """Increment the urgency level by one."""
         self.urgency += 1
         self.save()
 
     def decrease_urgency(self) -> None:
+        """Decrement the urgency level by one."""
         self.urgency -= 1
         self.save()
 
     def toggle_complete(self) -> None:
+        """Toggle the completion status between pending and completed."""
         self.pending = not self.pending
         self.save()
 
     def is_due_today(self) -> bool:
+        """Check whether the todo is due today."""
+
         if not self.due:
             return False
 
@@ -164,14 +187,18 @@ class Todo(DooitModel):
 
     @property
     def is_completed(self) -> bool:
+        """Check whether the todo has been marked as completed."""
         return self.pending == False
 
     @property
     def is_pending(self) -> bool:
+        """Check whether the todo is still pending."""
         return self.pending
 
     @property
     def is_overdue(self) -> bool:
+        """Check whether the todo is past its due date and still pending."""
+
         if not self.due:
             return False
 
@@ -179,11 +206,15 @@ class Todo(DooitModel):
 
     @classmethod
     def all(cls) -> List["Todo"]:
+        """Return all Todo instances from the database."""
+
         query = select(Todo)
         return list(manager.session.execute(query).scalars().all())
 
     @staticmethod
     def clone_from_id(id: int, order_index: int) -> "Todo":
+        """Create a deep copy of the Todo identified by the given id, including all nested children."""
+
         todo = Todo.from_id(str(id))
         fields = ["description", "due", "effort", "recurrence", "urgency", "pending"]
         attrs = {field: getattr(todo, field) for field in fields}

--- a/dooit/api/workspace.py
+++ b/dooit/api/workspace.py
@@ -10,6 +10,10 @@ ModelTypeList = Union[List["Workspace"], List["Todo"]]
 
 
 class Workspace(DooitModel):
+    """
+    Model representing a workspace, which can contain nested workspaces and todos.
+    """
+
     # id: Mapped[int] = mapped_column(primary_key=True, default=generate_unique_id)
     id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
     order_index: Mapped[int] = mapped_column(default=-1)
@@ -54,6 +58,8 @@ class Workspace(DooitModel):
 
     @classmethod
     def from_id(cls, _id: str) -> "Workspace":
+        """Look up and return a Workspace instance by its string identifier."""
+
         _id = _id.lstrip("Workspace_")
         query = select(Workspace).where(Workspace.id == _id)
         res = manager.session.execute(query).scalars().first()
@@ -62,14 +68,18 @@ class Workspace(DooitModel):
 
     @property
     def parent(self) -> Optional["Workspace"]:
+        """Return the parent workspace, or None if this is a top-level workspace."""
         return self.parent_workspace
 
     @property
     def has_same_parent_kind(self) -> bool:
+        """Check whether the parent is also a Workspace."""
         return self.parent is not None
 
     @property
     def siblings(self) -> List["Workspace"]:
+        """Return a list of sibling Workspace items sharing the same parent."""
+
         if not self.parent_workspace:
             return []
 
@@ -78,6 +88,8 @@ class Workspace(DooitModel):
         return self.parent_workspace.workspaces
 
     def sort_siblings(self, field: str):
+        """Sort sibling workspaces by the given field name."""
+
         items = (
             self.session.query(Workspace)
             .filter_by(
@@ -93,11 +105,15 @@ class Workspace(DooitModel):
         manager.commit()
 
     def add_workspace(self) -> "Workspace":
+        """Create and return a new child Workspace nested under this one."""
+
         workspace = Workspace(parent_workspace=self)
         workspace.save()
         return workspace
 
     def add_todo(self) -> "Todo":
+        """Create and return a new Todo belonging to this workspace."""
+
         todo = Todo(parent_workspace=self)
         todo.save()
         return todo
@@ -111,6 +127,8 @@ class Workspace(DooitModel):
         return workspace
 
     def save(self) -> None:
+        """Persist the workspace, assigning it to the root workspace if it has no parent."""
+
         if not self.parent_workspace and not self.is_root:
             root = self._get_or_create_root()
             self.parent_workspace = root
@@ -119,11 +137,15 @@ class Workspace(DooitModel):
 
     @classmethod
     def all(cls) -> List["Workspace"]:
+        """Return all non-root Workspace instances from the database."""
+
         query = select(Workspace).where(Workspace.is_root == False)
         return list(manager.session.execute(query).scalars().all())
 
     @staticmethod
     def clone_from_id(id: int, order_index: int) -> "Workspace":
+        """Create a deep copy of the Workspace identified by the given id, including all nested children and todos."""
+
         workspace = Workspace.from_id(str(id))
         fields = ["description"]
         attrs = {field: getattr(workspace, field) for field in fields}


### PR DESCRIPTION
## Summary
- Add triple double-quote docstrings to all public classes and methods in `dooit/api/` (model.py, todo.py, workspace.py, manager.py, theme.py)
- Follows existing project conventions (multi-line for classes, single/multi-line for methods)
- Skips private methods, dunder methods, and files that already have complete docstrings (exceptions.py)
- No logic changes — docstrings only

## Test plan
- [x] Verified all existing tests pass (75 passed; 6 pre-existing failures due to missing `faker` dependency)
- [x] Confirmed no code logic was modified via `git diff`

🤖 Generated with [Claude Code](https://claude.com/claude-code)