### PR TITLE
Add docstrings to tui.py and screens/

### DIFF
--- a/dooit/ui/screens/base.py
+++ b/dooit/ui/screens/base.py
@@ -19,6 +19,7 @@ class BaseScreen(Screen, inherit_bindings=False):
 
     @property
     def app(self) -> "Dooit":
+        """Return the running Dooit application instance."""
         from ..tui import Dooit
 
         app = super().app
@@ -28,9 +29,11 @@ class BaseScreen(Screen, inherit_bindings=False):
 
     @property
     def api(self) -> "DooitAPI":
+        """Return the DooitAPI instance from the application."""
         return self.app.api
 
     def resolve_key(self, event: events.Key) -> str:
+        """Resolve a Key event to a string representation of the pressed key."""
         if not event.character:
             return event.key
 

--- a/dooit/ui/screens/help.py
+++ b/dooit/ui/screens/help.py
@@ -11,6 +11,12 @@ from .base import BaseScreen
 
 
 class HelpWidget(Static):
+    """
+    Base static widget used by all components on the help screen.
+
+    Provides shared CSS defaults for centering and sizing.
+    """
+
     DEFAULT_CSS = """
     HelpWidget {
         content-align: center middle;
@@ -21,11 +27,21 @@ class HelpWidget(Static):
 
 
 class Header(HelpWidget):
+    """
+    Header widget that displays the welcome message at the top of the help screen.
+    """
+
     def render(self) -> RenderableType:
+        """Render the welcome message."""
         return "Welcome to Dooit!"
 
 
 class Outro(HelpWidget):
+    """
+    Footer widget that displays credits, a GitHub link, and navigation hints
+    at the bottom of the help screen.
+    """
+
     COMPONENT_CLASSES = {
         "exit",
         "thanks",
@@ -33,6 +49,7 @@ class Outro(HelpWidget):
     }
 
     def render(self) -> RenderableType:
+        """Render the credits, GitHub link, and escape hint."""
         thanks = Text.from_markup(
             "     Thanks for using Dooit <3",
             style=self.get_component_rich_style("thanks"),
@@ -57,6 +74,10 @@ class Outro(HelpWidget):
 
 
 class DooitKeyTable(HelpWidget):
+    """
+    Widget that renders a table of all configured keybindings grouped by category.
+    """
+
     DEFAULT_CSS = """
     DooitKeyTable {
         padding: 1 2;
@@ -77,6 +98,7 @@ class DooitKeyTable(HelpWidget):
         self.no_op = no_op
 
     def render(self) -> RenderableType:
+        """Render all keybinding groups as styled Rich tables."""
         tables = []
 
         for group in self.keybinds.groups:
@@ -129,18 +151,23 @@ class HelpScreen(BaseScreen):
     ]
 
     def compose(self) -> ComposeResult:
+        """Compose the help screen with header, key table, and outro widgets."""
         yield Header()
         yield DooitKeyTable(self.api.keys, self.api.no_op)
         yield Outro()
 
     def key_down(self):
+        """Scroll the help screen down using the down arrow key."""
         self.scroll_down()
 
     def key_up(self):
+        """Scroll the help screen up using the up arrow key."""
         self.scroll_up()
 
     def key_j(self):
+        """Scroll the help screen down using the j key."""
         self.scroll_down()
 
     def key_k(self):
+        """Scroll the help screen up using the k key."""
         self.scroll_up()

--- a/dooit/ui/screens/index.py
+++ b/dooit/ui/screens/index.py
@@ -30,6 +30,10 @@ from .base import BaseScreen
 
 
 class DualSplit(Container):
+    """
+    A two-column grid container that holds the workspace and todo panels side by side.
+    """
+
     DEFAULT_CSS = """
     DualSplit {
         layout: grid;
@@ -40,14 +44,28 @@ class DualSplit(Container):
 
 
 class DualSplitLeft(Container):
+    """
+    Container for the left panel of the dual-split layout (workspaces).
+    """
+
     pass
 
 
 class DualSplitRight(Container):
+    """
+    Container for the right panel of the dual-split layout (todos).
+    """
+
     pass
 
 
 class MainScreen(BaseScreen):
+    """
+    The primary screen of Dooit, containing the workspace tree, todo lists,
+    dashboard, and status bar. Handles key routing and SQLAlchemy event listeners
+    for tracking model field changes.
+    """
+
     DEFAULT_CSS = """
     MainScreen {
         layout: grid;
@@ -57,6 +75,7 @@ class MainScreen(BaseScreen):
     """
 
     def compose(self):
+        """Compose the main screen with workspace tree, todo switcher, dashboard, and status bar."""
         workspaces_tree = WorkspacesTree(Workspace._get_or_create_root())
 
         with DualSplit():
@@ -69,6 +88,7 @@ class MainScreen(BaseScreen):
         yield BarSwitcher()
 
     async def handle_key(self, event: events.Key) -> bool:
+        """Route key events to the bar switcher or the API key handler."""
         # NOTE: Investigate why keys are sent to this screen
         if self.app.screen != self:
             return True
@@ -83,34 +103,41 @@ class MainScreen(BaseScreen):
 
     @on(BarNotification)
     def show_notification(self, event: BarNotification):
+        """Display a notification message in the status bar."""
         self.app.bar_switcher.switch_to_notification(event)
 
     @on(SwitchTab)
     def switch_tab(self, event: SwitchTab) -> None:
+        """Switch focus to the next widget when a tab switch is requested."""
         event.stop()
         self.app.action_focus_next()
 
     @on(SpawnHelp)
     async def spawn_help(self, _: SpawnHelp) -> None:
+        """Push the help screen onto the screen stack."""
         self.app.push_screen("help")
 
     @on(StartSearch)
     def start_search(self, event: StartSearch):
+        """Activate the search bar and switch to SEARCH mode."""
         self.app.bar_switcher.switch_to_search(event.callback)
         self.post_message(ModeChanged("SEARCH"))
 
     @on(StartSort)
     def start_sort(self, event: StartSort):
+        """Activate the sort bar and switch to SORT mode."""
         self.app.bar_switcher.switch_to_sort(event.model, event.callback)
         self.post_message(ModeChanged("SORT"))
 
     @on(ShowConfirm)
     def show_confirm(self, event: ShowConfirm):
+        """Activate the confirmation bar and switch to CONFIRM mode."""
         self.app.bar_switcher.switch_to_confirm(event.callback)
         self.post_message(ModeChanged("CONFIRM"))
 
     @on(WorkspaceSelected)
     async def workspace_selected(self, event: WorkspaceSelected):
+        """Switch to or create the todo tree for the selected workspace."""
         switcher = self.query_one("#todo_switcher", expect_type=ContentSwitcher)
         tree = TodosTree(event.workspace)
 

--- a/dooit/ui/tui.py
+++ b/dooit/ui/tui.py
@@ -22,6 +22,13 @@ PRINTABLE = (
 
 
 class Dooit(App):
+    """
+    Main application class for Dooit, a terminal-based todo manager.
+
+    Manages the overall application lifecycle, screen navigation, plugin loading,
+    and database polling for external changes.
+    """
+
     CSS_PATH = CssManager().css_file
     ENABLE_COMMAND_PALETTE = False
 
@@ -45,6 +52,7 @@ class Dooit(App):
         manager.connect(db_path)
 
     async def base_setup(self):
+        """Initialize the API, scan for plugins, and push the main screen."""
         self.api = DooitAPI(self)
         self.api.plugin_manager.scan()
         self.post_message(Startup())
@@ -52,6 +60,7 @@ class Dooit(App):
         self.push_screen("main")
 
     async def setup_poller(self):
+        """Set up a periodic timer to poll the database for external changes."""
         self.set_interval(1, self.poll_dooit_db)
 
     async def on_mount(self):
@@ -64,20 +73,25 @@ class Dooit(App):
 
     @property
     def workspace_tree(self) -> WorkspacesTree:
+        """Return the WorkspacesTree widget from the current screen."""
         return self.screen.query_one(WorkspacesTree)
 
     @property
     def bar(self) -> StatusBar:
+        """Return the StatusBar widget from the current screen."""
         return self.screen.query_one(BarSwitcher).status_bar
 
     @property
     def bar_switcher(self) -> BarSwitcher:
+        """Return the BarSwitcher widget from the current screen."""
         return self.screen.query_one(BarSwitcher)
 
     def get_dooit_mode(self) -> ModeType:
+        """Return the current application mode (e.g. NORMAL, SEARCH, SORT)."""
         return self.dooit_mode
 
     async def poll_dooit_db(self):  # pragma: no cover
+        """Check for external database changes and refresh all trees if needed."""
         def refresh_all_trees():
             trees = self.screen.query(ModelTree)
             for tree in trees:
@@ -88,16 +102,19 @@ class Dooit(App):
 
     @on(DooitEvent)
     def global_message(self, event: DooitEvent):
+        """Dispatch a DooitEvent to the plugin API and refresh the status bar."""
         if isinstance(self.screen, MainScreen):
             self.api.trigger_event(event)
             self.bar.refresh()
 
     @on(ShutDown)
     def shutdown(self, _: ShutDown):
+        """Clean up CSS resources on application shutdown."""
         self.api.css.cleanup()
 
     @on(ModeChanged)
     def change_status(self, event: ModeChanged):
+        """Update the application mode and refresh tree options when returning to NORMAL."""
         self.dooit_mode = event.mode
         if event.mode == "NORMAL":
             self.workspace_tree.refresh_options()
@@ -107,6 +124,7 @@ class Dooit(App):
 
     @on(QuitApp)
     async def quit_app(self):
+        """Handle the QuitApp event by triggering the quit action."""
         await self.action_quit()
 
     async def action_open_url(self, url: str) -> None:  # pragma: no cover


### PR DESCRIPTION
## Summary
- Add triple double-quote docstrings to all public classes and methods in `dooit/ui/tui.py`, `dooit/ui/screens/base.py`, `dooit/ui/screens/help.py`, and `dooit/ui/screens/index.py`
- No code logic was modified; docstring-only changes
- Skips private (`_`-prefixed) and dunder methods per convention

## Test plan
- [x] All existing unit tests pass (75 passed; 6 pre-existing failures from missing `faker` dependency)
- [x] Verified no code logic was changed via `git diff`

🤖 Generated with [Claude Code](https://claude.com/claude-code)