### PR TITLE
Add docstrings to public classes and methods in trees/ widgets

### DIFF
--- a/dooit/ui/widgets/trees/_decorators.py
+++ b/dooit/ui/widgets/trees/_decorators.py
@@ -10,6 +10,8 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 def fix_highlight(func: Callable) -> Callable:
+    """Decorator that preserves the currently highlighted node after the wrapped function executes."""
+
     def wrapper(self: "ModelTree", *args, **kwargs) -> Any:
         highlighted_id = self.node.id if self.highlighted is not None else None
         highlighted_index = self.highlighted
@@ -29,6 +31,8 @@ def fix_highlight(func: Callable) -> Callable:
 
 
 def refresh_tree(func: Callable) -> Callable:
+    """Decorator that forces a tree refresh after the wrapped function executes."""
+
     def wrapper(self: "ModelTree", *args, **kwargs) -> Any:
         res = func(self, *args, **kwargs)
         self.force_refresh()
@@ -38,6 +42,8 @@ def refresh_tree(func: Callable) -> Callable:
 
 
 def require_highlighted_node(func: Callable) -> Callable:
+    """Decorator that raises NoNodeError if no node is currently highlighted."""
+
     def wrapper(self: "ModelTree", *args, **kwargs) -> Any:
         if self.highlighted is None:
             raise NoNodeError()
@@ -48,6 +54,8 @@ def require_highlighted_node(func: Callable) -> Callable:
 
 
 def require_confirmation(func: Callable) -> Callable:
+    """Decorator that shows a confirmation dialog before executing the wrapped function, if enabled."""
+
     def wrapper(self: "ModelTree", *args, **kwargs) -> Any:
         function = partial(func, self, *args, **kwargs)
 

--- a/dooit/ui/widgets/trees/_render_dict.py
+++ b/dooit/ui/widgets/trees/_render_dict.py
@@ -22,6 +22,7 @@ class RenderDict(Dict, Generic[T]):
         self.tree = tree
 
     def from_id(self, _id: str) -> T:
+        """Create and return a renderer instance for the given model ID."""
         raise NotImplementedError  # pragma: no cover
 
     def __getitem__(self, __key: str) -> T:
@@ -38,6 +39,7 @@ class WorkspaceRenderDict(RenderDict[WorkspaceRender]):
     """
 
     def from_id(self, _id: str) -> WorkspaceRender:
+        """Create and return a WorkspaceRender for the workspace with the given ID."""
         w = Workspace.from_id(_id)
         return WorkspaceRender(w, self.tree)
 
@@ -48,5 +50,6 @@ class TodoRenderDict(RenderDict[TodoRender]):
     """
 
     def from_id(self, _id: str) -> TodoRender:
+        """Create and return a TodoRender for the todo with the given ID."""
         t = Todo.from_id(_id)
         return TodoRender(t, self.tree)

--- a/dooit/ui/widgets/trees/base_tree.py
+++ b/dooit/ui/widgets/trees/base_tree.py
@@ -14,14 +14,21 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 class BaseTree(OptionList, can_focus=True, inherit_bindings=False):
+    """
+    Base tree widget that extends OptionList with node expansion tracking
+    and cursor movement behavior for tree-style navigation.
+    """
+
     expanded_nodes = defaultdict(bool)
 
     @property
     def api(self) -> "DooitAPI":
+        """Return the Dooit API instance."""
         return self.tui.api
 
     @property
     def tui(self) -> "Dooit":
+        """Return the parent Dooit application instance."""
         from ....ui.tui import Dooit
 
         assert isinstance(self.app, Dooit)
@@ -30,16 +37,19 @@ class BaseTree(OptionList, can_focus=True, inherit_bindings=False):
     @property
     @require_highlighted_node
     def node(self) -> Option:
+        """Return the currently highlighted option node."""
         assert self.highlighted is not None
         return self.get_option_at_index(self.highlighted)
 
     def action_cursor_down(self) -> None:
+        """Move the cursor down, stopping at the last option."""
         if self.highlighted == len(self._options) - 1:
             return
 
         return super().action_cursor_down()
 
     def action_cursor_up(self) -> None:
+        """Move the cursor up, stopping at the first option."""
         if self.highlighted == 0:
             return
 

--- a/dooit/ui/widgets/trees/model_tree.py
+++ b/dooit/ui/widgets/trees/model_tree.py
@@ -31,6 +31,12 @@ RenderDictType = TypeVar("RenderDictType", bound=RenderDict)
 
 
 class ModelTree(BaseTree, Generic[ModelType, RenderDictType]):
+    """
+    Generic tree widget for displaying and interacting with hierarchical
+    model data (Todos or Workspaces) with support for editing, filtering,
+    sorting, and clipboard operations.
+    """
+
     DEFAULT_CSS = """
     ModelTree {
         height: 1fr;
@@ -54,18 +60,22 @@ class ModelTree(BaseTree, Generic[ModelType, RenderDictType]):
 
     @cache
     def get_column_width(self, attr: str) -> int:
+        """Return the maximum rendered width for the given attribute across all renderers."""
         return max(i._get_attr_width(attr) for i in self._renderers.values())
 
     @property
     def formatter(self) -> "ModelFormatterBase":
+        """Return the formatter used to render model attributes."""
         raise NotImplementedError  # pragma: no cover
 
     @property
     def render_layout(self) -> Any:
+        """Return the layout configuration for rendering columns."""
         raise NotImplementedError  # pragma: no cover
 
     @property
     def filter_refresh(self):
+        """Return whether a filter-triggered refresh is currently active."""
         return self._filter_refresh
 
     @filter_refresh.setter
@@ -78,6 +88,7 @@ class ModelTree(BaseTree, Generic[ModelType, RenderDictType]):
 
     @property
     def current(self) -> BaseRenderer:
+        """Return the renderer for the currently highlighted node."""
         _id = self.node.id
         assert _id is not None
 
@@ -85,24 +96,29 @@ class ModelTree(BaseTree, Generic[ModelType, RenderDictType]):
 
     @property
     def current_model(self) -> ModelType:
+        """Return the model instance for the currently highlighted node."""
         return self.current.model
 
     def update_prompt_at_index(self, index: int):
+        """Re-render the display prompt for the option at the given index."""
         option = self.get_option_at_index(index)
         assert option.id is not None
 
         self.update_prompt_by_id(option.id)
 
     def update_prompt_by_id(self, _id: str):
+        """Re-render the display prompt for the option with the given ID."""
         renderer = self._renderers[_id]
         self.replace_option_prompt(_id, renderer.prompt)
 
     def update_current_prompt(self):
+        """Re-render the display prompt for the currently highlighted option."""
         if self.highlighted is not None:
             self.update_prompt_at_index(self.highlighted)
             self.scroll_to_highlight()
 
     def set_filter(self, filter: str) -> None:
+        """Apply a text filter to show only matching options, or clear the filter if empty."""
         self.filter_refresh = bool(filter)
 
         for option in self._options:
@@ -115,22 +131,27 @@ class ModelTree(BaseTree, Generic[ModelType, RenderDictType]):
 
     @property
     def is_editing(self) -> bool:
+        """Return whether the currently highlighted node is in edit mode."""
         return self.highlighted is not None and self.current.editing != ""
 
     @property
     def model(self) -> ModelType:
+        """Return the root model associated with this tree."""
         return self._model
 
     @property
     def empty_message(self) -> Label:
+        """Return the label widget displayed when the tree has no items."""
         return self.query_one("#empty_message", expect_type=Label)
 
     @fix_highlight
     def force_refresh(self) -> None:
+        """Rebuild all tree options from the model and clear cached column widths."""
         self._force_refresh()
         self.get_column_width.cache_clear()
 
     def is_node_expaned(self, _id: str) -> bool:
+        """Return whether the node with the given ID is currently expanded."""
         return self.expanded_nodes[_id]
 
     def _force_refresh(self) -> None:
@@ -163,13 +184,16 @@ class ModelTree(BaseTree, Generic[ModelType, RenderDictType]):
 
     @require_highlighted_node
     def start_sort(self):
+        """Initiate sorting of the current node's siblings."""
         self.post_message(StartSort(self.current_model, self.sort))
 
     @require_highlighted_node
     def start_search(self):
+        """Initiate a search/filter operation on the tree."""
         self.post_message(StartSearch(self.set_filter))
 
     def start_edit(self, property: str) -> bool:
+        """Begin editing the specified property on the current node. Return True if editing started."""
         columns = [i.value for i in self.render_layout]
         if property not in columns:
             self.post_message(
@@ -185,6 +209,7 @@ class ModelTree(BaseTree, Generic[ModelType, RenderDictType]):
         return res
 
     def stop_edit(self):
+        """Stop editing the current node and switch back to normal mode."""
         try:
             self.current.stop_edit()
         except Exception as e:  # pragma: no cover
@@ -201,6 +226,7 @@ class ModelTree(BaseTree, Generic[ModelType, RenderDictType]):
         self.set_filter("")
 
     async def handle_keypress(self, key: str) -> bool:
+        """Handle a keypress event, delegating to the editor if active."""
         if self.is_editing:
             if key in ["escape", "enter"]:
                 self.stop_edit()
@@ -219,6 +245,7 @@ class ModelTree(BaseTree, Generic[ModelType, RenderDictType]):
         return True
 
     def refresh_options(self) -> None:
+        """Re-render the display prompts for all options in the tree."""
         for i in self._options:
             assert i.id is not None
             new_prompt = self._renderers[i.id].prompt
@@ -229,6 +256,7 @@ class ModelTree(BaseTree, Generic[ModelType, RenderDictType]):
 
     @require_highlighted_node
     def copy_description_to_clipboard(self):
+        """Copy the description of the current node to the system clipboard."""
         self.app.copy_to_clipboard(self.current_model.description)
 
     @refresh_tree
@@ -236,6 +264,7 @@ class ModelTree(BaseTree, Generic[ModelType, RenderDictType]):
         self.expanded_nodes[_id] = True
 
     def expand_node(self) -> None:
+        """Expand the currently highlighted node to show its children."""
         if self.highlighted is not None and self.node.id:
             self._expand_node(self.node.id)
 
@@ -252,6 +281,7 @@ class ModelTree(BaseTree, Generic[ModelType, RenderDictType]):
 
     @require_highlighted_node
     def toggle_expand(self) -> None:
+        """Toggle the expand/collapse state of the currently highlighted node."""
         self._toggle_expand_node(self.node.id)
 
     def _toggle_expand_parent(self, _id: str) -> None:
@@ -266,12 +296,14 @@ class ModelTree(BaseTree, Generic[ModelType, RenderDictType]):
 
     @require_highlighted_node
     def toggle_expand_parent(self) -> None:
+        """Toggle the expand/collapse state of the parent of the currently highlighted node."""
         self._toggle_expand_parent(self.node.id)
 
     def _create_child_node(self) -> ModelType:
         raise NotImplementedError  # pragma: no cover
 
     def add_child_node(self):
+        """Create a new child node under the current node and begin editing its description."""
         node = self._create_child_node()
         node.description = ""
         node.save()
@@ -284,6 +316,7 @@ class ModelTree(BaseTree, Generic[ModelType, RenderDictType]):
         return self.current_model.add_sibling()
 
     def highlight_id(self, _id: str):
+        """Set the highlight to the option with the given ID."""
         self.highlighted = self.get_option_index(_id)
 
     @refresh_tree
@@ -295,12 +328,14 @@ class ModelTree(BaseTree, Generic[ModelType, RenderDictType]):
 
     @refresh_tree
     def add_first_item(self) -> ModelType:
+        """Add the first item to an empty tree."""
         return self._add_first_item()
 
     def _add_first_item(self) -> ModelType:
         raise NotImplementedError  # pragma: no cover
 
     def add_sibling(self):
+        """Create a new sibling node next to the current node and begin editing its description."""
         if self.is_editing:
             return
 
@@ -323,6 +358,7 @@ class ModelTree(BaseTree, Generic[ModelType, RenderDictType]):
 
     @require_highlighted_node
     def copy_model_to_clipboard(self):
+        """Copy the current model node to the internal clipboard."""
         node_type = self.current_model.__class__.__name__
         self.api.notify(f"{node_type} was copied to clipboard")
         self._model_clipboard = self.current_model.id
@@ -330,6 +366,7 @@ class ModelTree(BaseTree, Generic[ModelType, RenderDictType]):
     def paste_model_from_clipboard(
         self, position: str = "below"
     ) -> Optional[ModelType]:
+        """Clone the model from the internal clipboard and insert it at the given position."""
         @refresh_tree
         def add_node(self):
             if not self._model_clipboard:
@@ -362,26 +399,32 @@ class ModelTree(BaseTree, Generic[ModelType, RenderDictType]):
 
     @require_highlighted_node
     def remove_node(self):
+        """Remove the currently highlighted node from the tree."""
         self._remove_node()
 
     @refresh_tree
     def shift_up(self) -> None:
+        """Move the current node up among its siblings."""
         self.current_model.shift_up()
 
     @refresh_tree
     def shift_down(self):
+        """Move the current node down among its siblings."""
         self.current_model.shift_down()
 
     @refresh_tree
     def sort(self, attr: str):
+        """Sort the current node's siblings by the given attribute, or reverse their order."""
         if attr == "reverse":
             self.current_model.reverse_siblings()
         else:
             self.current_model.sort_siblings(attr)
 
     def show_help(self):
+        """Display the help screen."""
         self.app.push_screen("help")
 
     def compose(self) -> ComposeResult:
+        """Compose the tree widget with an empty-state message label."""
         with Label(id="empty_message"):
             yield Label("No items to display")

--- a/dooit/ui/widgets/trees/todos_tree.py
+++ b/dooit/ui/widgets/trees/todos_tree.py
@@ -18,6 +18,11 @@ Model = Union[Todo, Workspace]
 
 
 class TodosTree(ModelTree[Model, TodoRenderDict]):
+    """
+    Tree widget for displaying and managing Todo items,
+    with support for completion toggling and urgency adjustments.
+    """
+
     BORDER_TITLE = "Todos"
 
     def __init__(self, model: Model) -> None:
@@ -27,17 +32,21 @@ class TodosTree(ModelTree[Model, TodoRenderDict]):
         return Todo.from_id(id).parent_todo
 
     def is_node_expaned(self, _id: str) -> bool:
+        """Return whether the given todo node is expanded, respecting the always-expand setting."""
         return super().is_node_expaned(_id) or self.api.vars.always_expand_todos
 
     @property
     def formatter(self) -> "TodoFormatter":
+        """Return the todo formatter from the API."""
         return self.api.formatter.todos
 
     @property
     def render_layout(self):
+        """Return the todo layout configuration from the API."""
         return self.api.layouts.todo_layout
 
     def add_todo(self) -> str:
+        """Add a new todo to the tree and return its UUID."""
         todo = self.model.add_todo()
         render = TodoRender(todo, tree=self)
         self.add_option(Option(render.prompt, id=render.id))
@@ -56,18 +65,21 @@ class TodosTree(ModelTree[Model, TodoRenderDict]):
         return super()._remove_node()
 
     def toggle_complete(self):
+        """Toggle the completion status of the current todo."""
         assert isinstance(self.current_model, Todo)
 
         self.current_model.toggle_complete()
         self.refresh_options()
 
     def increase_urgency(self):
+        """Increase the urgency level of the current todo."""
         assert isinstance(self.current_model, Todo)
 
         self.current_model.increase_urgency()
         self.update_current_prompt()
 
     def decrease_urgency(self):
+        """Decrease the urgency level of the current todo."""
         assert isinstance(self.current_model, Todo)
 
         self.current_model.decrease_urgency()
@@ -75,6 +87,7 @@ class TodosTree(ModelTree[Model, TodoRenderDict]):
 
     @on(ModelTree.OptionHighlighted)
     def todo_highlighted(self, event: ModelTree.OptionHighlighted):
+        """Handle a todo being highlighted by posting a TodoSelected event."""
         assert event.option_id
 
         event.stop()

--- a/dooit/ui/widgets/trees/workspaces_tree.py
+++ b/dooit/ui/widgets/trees/workspaces_tree.py
@@ -18,6 +18,11 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 class WorkspacesTree(ModelTree[Workspace, WorkspaceRenderDict]):
+    """
+    Tree widget for displaying and managing Workspace items,
+    with support for nested workspace hierarchies.
+    """
+
     BORDER_TITLE = "Workspaces"
 
     def __init__(self, model: Workspace) -> None:
@@ -28,17 +33,21 @@ class WorkspacesTree(ModelTree[Workspace, WorkspaceRenderDict]):
         return Workspace.from_id(id).parent_workspace
 
     def is_node_expaned(self, _id: str) -> bool:
+        """Return whether the given workspace node is expanded, respecting the always-expand setting."""
         return super().is_node_expaned(_id) or self.api.vars.always_expand_workspaces
 
     @property
     def formatter(self) -> "WorkspaceFormatter":
+        """Return the workspace formatter from the API."""
         return self.api.formatter.workspaces
 
     @property
     def render_layout(self):
+        """Return the workspace layout configuration from the API."""
         return self.api.layouts.workspace_layout
 
     def add_workspace(self) -> str:
+        """Add a new workspace to the tree and return its UUID."""
         workspace = self.model.add_workspace()
         renderer = self._renderers[workspace.uuid]
         self.add_option(Option(renderer.prompt, id=renderer.id))
@@ -56,6 +65,7 @@ class WorkspacesTree(ModelTree[Workspace, WorkspaceRenderDict]):
 
     @on(ModelTree.OptionHighlighted)
     def workspace_highlighted(self, event: ModelTree.OptionHighlighted):
+        """Handle a workspace being highlighted by posting a WorkspaceSelected event."""
         assert event.option_id
 
         event.stop()


### PR DESCRIPTION
## Summary
- Add triple double-quote docstrings to all public classes, methods, properties, and module-level decorator functions in `dooit/ui/widgets/trees/`
- Covers `base_tree.py`, `model_tree.py`, `todos_tree.py`, `workspaces_tree.py`, `_render_dict.py`, and `_decorators.py`
- No code logic changes — docstrings only

## Test plan
- [x] Verified diff contains only docstring additions (no logic changes)
- [ ] Unit tests pass (could not run locally due to SSL/env issues, but zero logic was modified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)