### PR TITLE
Add docstrings to core UI widgets

### DIFF
--- a/dooit/ui/widgets/base.py
+++ b/dooit/ui/widgets/base.py
@@ -18,17 +18,21 @@ class HelperWidget(Widget):
     _status: ModeType
 
     async def hide(self) -> None:
+        """Hide the widget and switch back to NORMAL mode."""
         self.styles.layer = "L1"
         self.display = False
         self.post_message(ModeChanged("NORMAL"))
 
     async def start(self) -> None:
+        """Show the widget and activate its associated mode."""
         self.styles.layer = "L4"
         self.display = True
         self.post_message(ModeChanged(self._status))
 
     async def cancel(self) -> None:
+        """Cancel the current operation and hide the widget."""
         await self.hide()
 
     async def stop(self):
+        """Stop the widget and finalize the current operation."""
         pass

--- a/dooit/ui/widgets/clipboard.py
+++ b/dooit/ui/widgets/clipboard.py
@@ -10,9 +10,11 @@ class Clipboard:
     data = None
 
     def copy(self, widget: TodoWidget):
+        """Copy the model data from the given todo widget to the clipboard."""
         model: DooitModel = widget.model
         self.data = model.commit()
 
     @property
     def has_data(self) -> bool:
+        """Return whether the clipboard currently holds any data."""
         return bool(self.data)

--- a/dooit/ui/widgets/dashboard.py
+++ b/dooit/ui/widgets/dashboard.py
@@ -5,6 +5,11 @@ from textual.widgets import Label, Static
 
 
 class Dashboard(Static):
+    """
+    A static widget that displays a centered dashboard view
+    composed of labeled items.
+    """
+
     DEFAULT_CSS = """
     Dashboard {
         align: center middle;
@@ -21,8 +26,10 @@ class Dashboard(Static):
     items = reactive([], recompose=True)
 
     def compose(self) -> ComposeResult:
+        """Compose the dashboard by yielding a Label for each item."""
         for i in self.items:
             yield Label(i)
 
     def render(self) -> RenderableType:
+        """Render the dashboard widget as an empty string."""
         return ""


### PR DESCRIPTION
## Summary
- Added docstrings to `HelperWidget`, `Clipboard`, `Dashboard` and their public methods in `dooit/ui/widgets/`
- No code logic changes, only documentation

## Test plan
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)