### PR TITLE
Add docstrings to formatter components

### DIFF
--- a/dooit/ui/api/api_components/formatters/_model_formatter_base.py
+++ b/dooit/ui/api/api_components/formatters/_model_formatter_base.py
@@ -7,15 +7,25 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 class ModelFormatterBase:
+    """
+    Base class for model-specific formatters.
+
+    Provides the scaffolding for creating and managing formatter stores
+    that control how model fields are rendered in the UI.
+    """
+
     def __init__(self, api: "DooitAPI") -> None:
         self.api = api
         self.setup_formatters()
 
     def get_formatter_store(self) -> FormatterStore:
+        """Create and return a new FormatterStore bound to this model formatter's trigger."""
         return FormatterStore(self.trigger, self.api)
 
     def setup_formatters(self) -> None:  # pragma: no cover
+        """Initialize formatter stores for each field. Override in subclasses."""
         pass
 
     def trigger(self) -> None:  # pragma: no cover
+        """Trigger a UI refresh for the associated widget tree. Override in subclasses."""
         pass

--- a/dooit/ui/api/api_components/formatters/formatter.py
+++ b/dooit/ui/api/api_components/formatters/formatter.py
@@ -8,6 +8,13 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 class Formatter(ApiComponent):
+    """
+    Top-level API component that exposes formatter stores for todos and workspaces.
+
+    Acts as a container providing access to TodoFormatter and WorkspaceFormatter
+    instances, allowing users to register custom formatting functions for model fields.
+    """
+
     def __init__(self, api: "DooitAPI") -> None:
         self.todos = TodoFormatter(api)
         self.workspaces = WorkspaceFormatter(api)

--- a/dooit/ui/api/api_components/formatters/formatter_store.py
+++ b/dooit/ui/api/api_components/formatters/formatter_store.py
@@ -14,12 +14,17 @@ FormatterReturnType = Union[str, Tuple[str, bool]]
 
 @dataclass
 class FormatterFunc:
+    """
+    Data container holding a named formatter function and its enabled/disabled state.
+    """
+
     name: str
     func: Callable
     disabled: bool = False
 
 
 def trigger_refresh(func: Callable) -> Callable:
+    """Decorator that triggers a UI refresh after the wrapped method executes."""
     def wrapper(self: "FormatterStore", *args, **kwargs):
         res = func(self, *args, **kwargs)
         self.trigger()
@@ -29,6 +34,13 @@ def trigger_refresh(func: Callable) -> Callable:
 
 
 class FormatterStore:
+    """
+    Manages a collection of formatter functions for a single model field.
+
+    Formatters are applied in reverse registration order when rendering values.
+    Supports adding, removing, enabling, and disabling individual formatters by ID.
+    """
+
     def __init__(self, trigger: Callable, api: "DooitAPI") -> None:
         self.formatters = dict()
         self.trigger = trigger
@@ -36,6 +48,7 @@ class FormatterStore:
 
     @trigger_refresh
     def add(self, func: Callable, id: Optional[str] = None) -> str:
+        """Register a formatter function and return its unique ID."""
         id = id or uuid4().hex
         self.formatters[id] = FormatterFunc(
             id,
@@ -44,14 +57,17 @@ class FormatterStore:
         return id
 
     def get_formatter_by_id(self, id: str) -> Optional[FormatterFunc]:
+        """Return the FormatterFunc with the given ID, or None if not found."""
         return self.formatters.get(id)
 
     @trigger_refresh
     def remove(self, id: str) -> None:
+        """Remove the formatter with the given ID, if it exists."""
         self.formatters.pop(id, None)
 
     @trigger_refresh
     def disable(self, id: str) -> bool:
+        """Disable the formatter with the given ID. Return True if found, False otherwise."""
         formatter = self.formatters.get(id)
         if not formatter:
             return False
@@ -61,6 +77,7 @@ class FormatterStore:
 
     @trigger_refresh
     def enable(self, id: str) -> bool:
+        """Enable the formatter with the given ID. Return True if found, False otherwise."""
         formatter = self.formatters.get(id)
         if not formatter:
             return False
@@ -70,6 +87,7 @@ class FormatterStore:
 
     @property
     def type1_formatter_functions(self) -> List[Callable]:
+        """Return enabled single-value (non-extra) formatter functions."""
         return [
             formatter.func
             for formatter in self.formatters.values()
@@ -79,6 +97,7 @@ class FormatterStore:
 
     @property
     def type2_formatter_functions(self) -> List[Callable]:
+        """Return enabled extra (multi-pass) formatter functions."""
         return [
             formatter.func
             for formatter in self.formatters.values()
@@ -90,6 +109,7 @@ class FormatterStore:
         return list(func.__code__.co_varnames)
 
     def format_value(self, value: Any, model: ModelType) -> Text:
+        """Apply all enabled formatters to the given value and return the resulting Rich Text."""
         params = dict(api=self.api)
 
         def get_extra_args(func: Callable) -> Dict[str, Any]:

--- a/dooit/ui/api/api_components/formatters/model_formatters.py
+++ b/dooit/ui/api/api_components/formatters/model_formatters.py
@@ -3,7 +3,15 @@ from dooit.ui.widgets.trees import TodosTree, WorkspacesTree
 
 
 class TodoFormatter(ModelFormatterBase):
+    """
+    Formatter for Todo model fields.
+
+    Provides formatter stores for description, due, effort, recurrence,
+    urgency, and status fields of todo items.
+    """
+
     def setup_formatters(self):
+        """Initialize formatter stores for each todo field."""
         self.description = self.get_formatter_store()
         self.due = self.get_formatter_store()
         self.effort = self.get_formatter_store()
@@ -12,14 +20,23 @@ class TodoFormatter(ModelFormatterBase):
         self.status = self.get_formatter_store()
 
     def trigger(self) -> None:
+        """Force a refresh on all TodosTree widgets in the current screen."""
         for widget in self.api.app.screen.query(TodosTree):
             widget.force_refresh()
 
 
 class WorkspaceFormatter(ModelFormatterBase):
+    """
+    Formatter for Workspace model fields.
+
+    Provides a formatter store for the description field of workspace items.
+    """
+
     def setup_formatters(self):
+        """Initialize formatter stores for each workspace field."""
         self.description = self.get_formatter_store()
 
     def trigger(self) -> None:
+        """Force a refresh on all WorkspacesTree widgets in the current screen."""
         for widget in self.api.app.screen.query(WorkspacesTree):
             widget.force_refresh()


### PR DESCRIPTION
## Summary
- Added docstrings to all public classes and methods in `dooit/ui/api/api_components/formatters/`
- Covers `ModelFormatterBase`, `Formatter`, `FormatterStore`, `FormatterFunc`, `TodoFormatter`, `WorkspaceFormatter`
- No code logic changes, only documentation

## Test plan
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)