### PR TITLE
Add docstrings to renderer widgets

### DIFF
--- a/dooit/ui/widgets/renderers/base_renderer.py
+++ b/dooit/ui/widgets/renderers/base_renderer.py
@@ -11,6 +11,13 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 class BaseRenderer(Generic[ModelType]):
+    """
+    Base renderer for tree model items.
+
+    Provides the core rendering logic that converts a model (Todo or Workspace)
+    into a Rich Table renderable, and manages inline editing of model attributes.
+    """
+
     editing: str = ""
 
     def __init__(self, model: ModelType, tree: "ModelTree"):
@@ -19,9 +26,11 @@ class BaseRenderer(Generic[ModelType]):
         self.post_init()
 
     def post_init(self):  # pragma: no cover
+        """Hook for subclass initialization, called at the end of __init__."""
         pass
 
     def matches_filter(self, filter: str) -> bool:
+        """Return True if the model's description contains the given filter string."""
         return filter in self.model.description
 
     def _get_component(self, component: str) -> SimpleInput:
@@ -29,18 +38,22 @@ class BaseRenderer(Generic[ModelType]):
 
     @property
     def id(self) -> str:
+        """Return the unique identifier of the underlying model."""
         return self._model.uuid
 
     @property
     def table_layout(self) -> List:
+        """Return the column layout used for rendering the table row."""
         return self.tree.render_layout
 
     @property
     def prompt(self) -> RenderableType:
+        """Return the renderable representation of this item."""
         return self.make_renderable()
 
     @property
     def model(self) -> ModelType:
+        """Return the underlying data model. Must be implemented by subclasses."""
         raise NotImplementedError  # pragma: no cover
 
     def _get_attr_width(self, attr: str) -> int:
@@ -56,6 +69,7 @@ class BaseRenderer(Generic[ModelType]):
         return self.tree.get_column_width(attr)
 
     def make_renderable(self) -> Table:
+        """Build and return a Rich Table representing this model as a grid row."""
         layout = self.table_layout
 
         table = Table.grid(expand=True, padding=(0, 1), pad_edge=True)
@@ -91,6 +105,7 @@ class BaseRenderer(Generic[ModelType]):
         return table
 
     def start_edit(self, param: str) -> bool:
+        """Begin editing the given attribute. Return True if editing started successfully."""
         if not hasattr(self, param):
             return False
 
@@ -99,10 +114,12 @@ class BaseRenderer(Generic[ModelType]):
         return True
 
     def stop_edit(self):
+        """Stop the current edit, clear the column width cache, and reset editing state."""
         getattr(self, self.editing).stop_edit()
         self.tree.get_column_width.cache_clear()
         self.editing = ""
 
     def handle_keypress(self, key: str) -> bool:
+        """Forward a keypress to the currently editing component and return True."""
         getattr(self, self.editing).keypress(key)
         return True

--- a/dooit/ui/widgets/renderers/todo_renderer.py
+++ b/dooit/ui/widgets/renderers/todo_renderer.py
@@ -10,11 +10,20 @@ from .base_renderer import BaseRenderer, Todo
 
 
 class TodoRender(BaseRenderer[Todo]):
+    """
+    Renderer for Todo model items.
+
+    Manages the input components for all editable Todo attributes
+    including description, due date, status, urgency, effort, and recurrence.
+    """
+
     @property
     def model(self) -> Todo:
+        """Return the underlying Todo model."""
         return self._model
 
     def post_init(self):
+        """Initialize input components for each editable Todo attribute."""
         self.description = TodoDescription(self.model)
         self.due = Due(self.model)
         self.status = Status(self.model)

--- a/dooit/ui/widgets/renderers/workspace_renderer.py
+++ b/dooit/ui/widgets/renderers/workspace_renderer.py
@@ -3,9 +3,17 @@ from ..inputs.model_inputs import WorkspaceDescription
 
 
 class WorkspaceRender(BaseRenderer[Workspace]):
+    """
+    Renderer for Workspace model items.
+
+    Manages the input component for the editable Workspace description attribute.
+    """
+
     @property
     def model(self) -> Workspace:
+        """Return the underlying Workspace model."""
         return self._model
 
     def post_init(self):
+        """Initialize the input component for the Workspace description."""
         self.description = WorkspaceDescription(self.model)


### PR DESCRIPTION
## Summary
- Added docstrings to `BaseRenderer`, `TodoRender`, `WorkspaceRender` and their public methods
- No code logic changes, only documentation

## Test plan
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)