### PR TITLE
Add docstrings to bar widgets

### DIFF
--- a/dooit/ui/widgets/bars/_base.py
+++ b/dooit/ui/widgets/bars/_base.py
@@ -11,6 +11,14 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 class BarBase(Static):
+    """
+    Abstract base class for all bar widgets in the application.
+
+    Provides common functionality for bars displayed at the bottom of the UI,
+    including access to the app, API, and bar switcher, as well as shared
+    dismiss and action handling logic.
+    """
+
     DEFAULT_CSS = """
     BarBase {
         height: 1;
@@ -26,6 +34,7 @@ class BarBase(Static):
 
     @property
     def app(self) -> "Dooit":
+        """Return the Dooit application instance."""
         from dooit.ui.tui import Dooit
 
         app = super().app
@@ -34,10 +43,12 @@ class BarBase(Static):
 
     @property
     def api(self) -> "DooitAPI":  # pragma: no cover
+        """Return the DooitAPI instance from the application."""
         return self.app.api
 
     @property
     def switcher(self) -> "BarSwitcher":
+        """Return the parent BarSwitcher that manages this bar."""
         from .bar_switcher import BarSwitcher
 
         parent = self.parent
@@ -49,9 +60,11 @@ class BarBase(Static):
         self.switcher.current = "status_bar"
 
     def perform_action(self, cancel: bool):
+        """Execute the bar's action. Subclasses must override this method."""
         raise NotImplementedError  # pragma: no cover
 
     def dismiss(self, cancel: bool):
+        """Dismiss the bar, performing its action and returning to normal mode."""
         self.perform_action(cancel)
         self.app.post_message(ModeChanged("NORMAL"))
         self.remove()

--- a/dooit/ui/widgets/bars/bar_switcher.py
+++ b/dooit/ui/widgets/bars/bar_switcher.py
@@ -13,6 +13,13 @@ from .sort_bar import SortBar
 
 
 class BarSwitcher(ContentSwitcher):
+    """
+    A content switcher that manages transitions between different bar widgets.
+
+    Handles mounting and switching between the status bar, search bar,
+    confirm bar, sort bar, and notification bar.
+    """
+
     DEFAULT_CSS = """
     BarSwitcher {
         height: 1;
@@ -22,10 +29,12 @@ class BarSwitcher(ContentSwitcher):
 
     @property
     def search_bar(self):
+        """Return the SearchBar widget instance."""
         return self.query_one(SearchBar)
 
     @property
     def visible_content(self) -> BarBase:
+        """Return the currently visible bar widget."""
         content = super().visible_content
 
         assert isinstance(content, BarBase)
@@ -33,11 +42,13 @@ class BarSwitcher(ContentSwitcher):
 
     @property
     def is_focused(self):
+        """Return whether the currently visible bar has focus."""
         return self.current != "status_bar" and self.visible_content.focused
 
     def add_content(
         self, widget: Widget, *, id: Optional[str] = None, set_current: bool = False
     ) -> AwaitComplete:
+        """Add a bar widget, removing any existing widget with the same id."""
         try:
             self.query_one(f"#{id}", expect_type=BarBase).remove()
         except Exception as _:
@@ -54,6 +65,7 @@ class BarSwitcher(ContentSwitcher):
         )
 
     def switch_to_search(self, callback: Callable):
+        """Switch the bar to display the search bar."""
         search_bar = SearchBar(callback)
         self.add_content(
             widget=search_bar,
@@ -62,6 +74,7 @@ class BarSwitcher(ContentSwitcher):
         )
 
     def switch_to_confirm(self, callback: Callable):
+        """Switch the bar to display the confirmation prompt."""
         confirm_bar = ConfirmBar(callback)
         self.add_content(
             widget=confirm_bar,
@@ -70,6 +83,7 @@ class BarSwitcher(ContentSwitcher):
         )
 
     def switch_to_sort(self, model: DooitModel, callback: Callable):
+        """Switch the bar to display the sort options for the given model."""
         sort_bar = SortBar(model, callback)
         self.add_content(
             widget=sort_bar,
@@ -78,6 +92,7 @@ class BarSwitcher(ContentSwitcher):
         )
 
     def switch_to_notification(self, event: BarNotification):
+        """Switch the bar to display a notification message."""
         notification_bar = NotificationBar(event.message, event.level, event.auto_exit)
         self.add_content(
             widget=notification_bar,
@@ -86,5 +101,6 @@ class BarSwitcher(ContentSwitcher):
         )
 
     async def handle_keypress(self, key: str) -> None:
+        """Forward a keypress to the currently visible bar widget."""
         if self.current != "status_bar":
             await self.visible_content.handle_keypress(key)

--- a/dooit/ui/widgets/bars/confirm_bar/bar.py
+++ b/dooit/ui/widgets/bars/confirm_bar/bar.py
@@ -8,6 +8,13 @@ DEFFAULT_MSG = r"Are you sure? \[y/N]"
 
 
 class ConfirmBar(BarBase):
+    """
+    A bar widget that prompts the user for yes/no confirmation.
+
+    Displays a confirmation message and executes the callback
+    only when the user confirms with 'y'.
+    """
+
     DEFAULT_CSS = """
     ConfirmBar {
         padding-left: 1;
@@ -26,10 +33,12 @@ class ConfirmBar(BarBase):
         self.message = message
 
     def perform_action(self, cancel: bool):
+        """Execute the confirmation callback if not cancelled."""
         if not cancel:
             self.callback()
 
     async def handle_keypress(self, key: str) -> None:
+        """Handle a keypress, confirming on 'y' and cancelling on any other key."""
         cancel = key.lower() != "y"
         self.dismiss(cancel)
         if cancel:
@@ -38,4 +47,5 @@ class ConfirmBar(BarBase):
             self.post_message(BarNotification("The items were deleted", "error"))
 
     def render(self) -> RenderableType:
+        """Render the confirmation message."""
         return self.message

--- a/dooit/ui/widgets/bars/notification_bar/bar.py
+++ b/dooit/ui/widgets/bars/notification_bar/bar.py
@@ -4,6 +4,13 @@ from .._base import BarBase
 
 
 class NotificationBar(BarBase):
+    """
+    A bar widget that displays notification messages to the user.
+
+    Supports different notification levels and can auto-dismiss
+    after a timeout or wait for a manual keypress to close.
+    """
+
     DEFAULT_CSS = """
     NotificationBar {
         padding-left: 1;
@@ -27,6 +34,7 @@ class NotificationBar(BarBase):
         self.add_class(self.level)
 
     def perform_action(self, cancel: bool):
+        """No-op since notifications do not perform any action on dismiss."""
         return
 
     def on_mount(self):
@@ -34,7 +42,9 @@ class NotificationBar(BarBase):
             self.app.set_interval(1, self.remove)
 
     async def handle_keypress(self, key: str) -> None:
+        """Dismiss the notification bar on any keypress."""
         self.remove()
 
     def render(self) -> RenderableType:
+        """Render the notification message."""
         return self.message

--- a/dooit/ui/widgets/bars/search_bar/bar.py
+++ b/dooit/ui/widgets/bars/search_bar/bar.py
@@ -6,16 +6,25 @@ from ...inputs._input import Input
 
 
 class SearchBar(BarBase):
+    """
+    A bar widget that provides an interactive search input.
+
+    Displays a text input prefixed with '/' and invokes the callback
+    with the current filter text as the user types.
+    """
+
     def __init__(self, callback: Callable, *args, **kwargs):
         super().__init__(callback, *args, **kwargs)
         self._search = Input(value="/")
         self._search.is_editing = True
 
     def perform_action(self, cancel: bool):
+        """Clear the search filter by invoking the callback with an empty string if cancelled."""
         if cancel:
             self.callback("")
 
     async def handle_keypress(self, key: str) -> None:
+        """Handle a keypress, confirming on enter, cancelling on escape, or updating the search."""
         if key == "enter":
             self.dismiss(cancel=False)
 
@@ -29,4 +38,5 @@ class SearchBar(BarBase):
             self.refresh()
 
     def render(self) -> RenderableType:
+        """Render the search input field."""
         return self._search.draw()

--- a/dooit/ui/widgets/bars/sort_bar/bar.py
+++ b/dooit/ui/widgets/bars/sort_bar/bar.py
@@ -6,6 +6,13 @@ from dooit.api import DooitModel
 
 
 class SortBar(BarBase):
+    """
+    A bar widget that presents sortable field options for a model.
+
+    Displays a horizontal list of sort options that can be navigated
+    with arrow keys and selected with enter.
+    """
+
     COMPONENT_CLASSES = {
         "option-highlighted",
     }
@@ -19,6 +26,7 @@ class SortBar(BarBase):
 
     @property
     def selected(self) -> int:
+        """Return the index of the currently selected sort option."""
         return self._selected
 
     @selected.setter
@@ -30,6 +38,7 @@ class SortBar(BarBase):
         self.refresh()
 
     def perform_action(self, cancel: bool):
+        """Invoke the callback with the selected sort field if not cancelled."""
         if cancel:
             return
 
@@ -37,6 +46,7 @@ class SortBar(BarBase):
         self.callback(selected)
 
     async def handle_keypress(self, key: str) -> None:
+        """Handle a keypress to navigate options or confirm/cancel the selection."""
         if key == "escape":
             return self.dismiss(cancel=True)
 
@@ -49,6 +59,7 @@ class SortBar(BarBase):
             self.selected += 1
 
     def render(self) -> RenderableType:
+        """Render the sort options with the current selection highlighted."""
         highlighted_style = self.get_component_rich_style("option-highlighted")
 
         texts = [

--- a/dooit/ui/widgets/bars/status_bar/bar.py
+++ b/dooit/ui/widgets/bars/status_bar/bar.py
@@ -7,13 +7,22 @@ from .bar_widget import StatusBarWidget
 
 
 class StatusBar(BarBase):
+    """
+    A bar widget that displays a row of configurable status bar widgets.
+
+    Serves as the default bar shown during normal operation, rendering
+    user-defined StatusBarWidget instances in a horizontal grid layout.
+    """
+
     bar_widgets = []
 
     def set_widgets(self, widgets: List[StatusBarWidget]) -> None:
+        """Set the list of status bar widgets and refresh the display."""
         self.bar_widgets = widgets
         self.refresh()
 
     def render(self) -> RenderableType:
+        """Render all status bar widgets as a horizontal grid table."""
         expand = any(widget.width == 0 for widget in self.bar_widgets)
         table = Table.grid(expand=expand, padding=0)
         row = []

--- a/dooit/ui/widgets/bars/status_bar/bar_widget.py
+++ b/dooit/ui/widgets/bars/status_bar/bar_widget.py
@@ -4,6 +4,13 @@ from typing import Optional
 
 
 class StatusBarWidget:
+    """
+    A single widget component rendered within the status bar.
+
+    Wraps a callable that produces rich text content and an optional
+    fixed width for column sizing in the status bar grid.
+    """
+
     def __init__(
         self, func: Callable[..., TextType], width: Optional[int] = None
     ) -> None:
@@ -12,6 +19,7 @@ class StatusBarWidget:
 
     @property
     def value(self) -> str:
+        """Return the current string value produced by the widget's function."""
         res = getattr(self.func, "__dooit_value", "")
 
         if isinstance(res, Text):
@@ -20,4 +28,5 @@ class StatusBarWidget:
         return str(res)
 
     def render(self) -> TextType:
+        """Render the widget's value as rich markup text."""
         return Text.from_markup(self.value)


### PR DESCRIPTION
## Summary
- Added docstrings to all bar widget classes: `BarBase`, `BarSwitcher`, `ConfirmBar`, `NotificationBar`, `SearchBar`, `SortBar`, `StatusBar`, `StatusBarWidget`
- No code logic changes, only documentation

## Test plan
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)